### PR TITLE
Update addon_config.mk

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -87,4 +87,5 @@ android/armeabi-v7a:
 
 ios:
 
-
+osx:
+	ADDON_INCLUDES_EXCLUDE = libs/tensorflow/include/Eigen/src/%


### PR DESCRIPTION
Fix #15 by excluding Eigen/src from includes on osx/Xcode

May be required on other platforms too, haven't tested