### PR TITLE
add ofxOpenCv dependency to webcam pix2pix example

### DIFF
--- a/example-pix2pix-webcam/addons.make
+++ b/example-pix2pix-webcam/addons.make
@@ -1,1 +1,2 @@
 ofxMSATensorFlow
+ofxOpenCv


### PR DESCRIPTION
Adds `ofxOpenCv` to the webcam pix2pix example, allows building with `make` 